### PR TITLE
move #include <atomic> to header to fix build

### DIFF
--- a/Source/relive_lib/Sound/SDLSoundBuffer.cpp
+++ b/Source/relive_lib/Sound/SDLSoundBuffer.cpp
@@ -1,6 +1,5 @@
 #include "../stdafx.h"
 #include "SDLSoundBuffer.hpp"
-#include <atomic>
 
 #define MAX_VOICE_COUNT 1024
 

--- a/Source/relive_lib/Sound/SDLSoundBuffer.hpp
+++ b/Source/relive_lib/Sound/SDLSoundBuffer.hpp
@@ -3,6 +3,7 @@
 #include "Sound.hpp"
 #include "SoundSDL.hpp"
 #include <mutex>
+#include <atomic>
 
 #define MAX_VOICE_COUNT 1024
 extern std::atomic<SDLSoundBuffer*> sAE_ActiveVoices[MAX_VOICE_COUNT];


### PR DESCRIPTION
This one file doesn't build on my machine, needed to move the include to the header